### PR TITLE
Implement new Prime protocol for sending files

### DIFF
--- a/libhpcalcs/README
+++ b/libhpcalcs/README
@@ -257,6 +257,11 @@ hpfiles INFO: Name:
   but I'm not really confident about it ;)
   Need to find a library for MSD. libusb does not recommend using it
   in MSD mode.
+* implement compressed file transfer. The HP connectivity kit switches
+  to a compressed transfer mode for files over a certain size when
+  connected to a Prime with recent firmware.
+* use the new Prime protocol throughout. Currently we use it only for
+  file transfers
 * certainly more... at least, if users and programmers think the software
   fits a purpose :-)
 

--- a/libhpcalcs/src/hpcalcs.h
+++ b/libhpcalcs/src/hpcalcs.h
@@ -389,14 +389,6 @@ HPEXPORT void HPCALL prime_vtl_pkt_del(prime_vtl_pkt * pkt);
 HPEXPORT int HPCALL prime_send_new_protocol_init(calc_handle * handle);
 
 /**
- * \brief Sends the given virtual packet to the Prime calculator using given calculator handle (new protocol).
- * \param handle the calculator handle.
- * \param pkt the virtual packet.
- * \return 0 upon success, nonzero otherwise.
- */
-HPEXPORT int HPCALL prime_send_data_new(calc_handle * handle, prime_vtl_pkt * pkt);
-
-/**
  * \brief Sends the given virtual packet to the Prime calculator using given calculator handle.
  * \param handle the calculator handle.
  * \param pkt the virtual packet.

--- a/libhpcalcs/src/hpcalcs.h
+++ b/libhpcalcs/src/hpcalcs.h
@@ -118,6 +118,7 @@ struct _calc_handle {
     int attached; // Should be made explicitly atomic with GCC >= 4.7 or Clang, but int is atomic on most ISAs anyway.
     int open; // Should be made explicitly atomic with GCC >= 4.7 or Clang, but int is atomic on most ISAs anyway.
     int busy; // Should be made explicitly atomic with GCC >= 4.7 or Clang, but int is atomic on most ISAs anyway.
+    int protocol_version;
 };
 
 
@@ -379,6 +380,21 @@ HPEXPORT prime_vtl_pkt * HPCALL prime_vtl_pkt_new_with_data_ptr(uint32_t size, u
  * \param pkt the packet to be deleted.
  */
 HPEXPORT void HPCALL prime_vtl_pkt_del(prime_vtl_pkt * pkt);
+
+/**
+ * \brief Switches the Prime into a new protocol mode.
+ * \param handle the calculator handle.
+ * \return 0 upon success, nonzero otherwise.
+ */
+HPEXPORT int HPCALL prime_send_new_protocol_init(calc_handle * handle);
+
+/**
+ * \brief Sends the given virtual packet to the Prime calculator using given calculator handle (new protocol).
+ * \param handle the calculator handle.
+ * \param pkt the virtual packet.
+ * \return 0 upon success, nonzero otherwise.
+ */
+HPEXPORT int HPCALL prime_send_data_new(calc_handle * handle, prime_vtl_pkt * pkt);
 
 /**
  * \brief Sends the given virtual packet to the Prime calculator using given calculator handle.

--- a/libhpcalcs/src/prime_cmd.c
+++ b/libhpcalcs/src/prime_cmd.c
@@ -382,6 +382,7 @@ HPEXPORT int HPCALL calc_prime_s_disable_new_protocol(calc_handle * handle) {
     int res;
     // It looks like sending a status check using the old protocol drops the Prime
     // out of the new protocol mode.
+    handle->protocol_version = 0;
     res = calc_prime_s_check_ready(handle);
     if (res) {
         return res;
@@ -395,6 +396,9 @@ HPEXPORT int HPCALL calc_prime_r_disable_new_protocol(calc_handle * handle) {
         // While the prime is in thew new protocol mode, it sends us packages
         // starting with 0xFE. We need to eliminate those now (and also wait for
         // the status response).
+        // We need to temporarily re-enable the new protocol, so that 0xFEs get
+        // eliminated and don't cause errors.
+        handle->protocol_version = 1;
         res = calc_prime_r_check_ready(handle, NULL, NULL);
         handle->protocol_version = 0;
     }

--- a/libhpcalcs/src/prime_cmd.c
+++ b/libhpcalcs/src/prime_cmd.c
@@ -116,10 +116,6 @@ static int read_vtl_pkt(calc_handle * handle, uint8_t cmd, prime_vtl_pkt ** pkt,
     return res;
 }
 
-static int write_vtl_pkt_new(calc_handle * handle, prime_vtl_pkt * pkt) {
-    return prime_send_data_new(handle, pkt);
-}
-
 static int write_vtl_pkt(calc_handle * handle, prime_vtl_pkt * pkt) {
     return prime_send_data(handle, pkt);
 }
@@ -415,8 +411,8 @@ HPEXPORT int HPCALL calc_prime_s_send_file(calc_handle * handle, files_var_entry
         uint32_t offset = 0;
         uint32_t header_size = 8;
         uint8_t namelen = (uint8_t)char16_strlen(file->name) * 2;
-        uint32_t size = namelen + file->size + 12; // Size of the data plus something
-        uint32_t other_size = namelen + file->size + 6; // Also size of the data plus something
+        uint32_t size = namelen + file->size + 10; // Size of the data plus something
+        uint32_t other_size = namelen + file->size + 4; // Also size of the data plus something
         prime_vtl_pkt * pkt;
 
         // Some text editors add the UTF-16LE BOM at the beginning of the file, but the SDKV0.30 firmware version chokes on it.
@@ -472,16 +468,12 @@ HPEXPORT int HPCALL calc_prime_s_send_file(calc_handle * handle, files_var_entry
 
             memcpy(ptr, file->data + offset, file->size - offset);
             ptr += file->size - offset;
-            
-            // Two extra nulls (for termination?
-            *ptr++ = 0x00;
-            *ptr++ = 0x00;
 
             crc16 = crc16_block(pkt->data + header_size, size); // Excluding the header
             pkt->data[16] = crc16 & 0xFF;
             pkt->data[17] = (crc16 >> 8) & 0xFF;
 
-            res = write_vtl_pkt_new(handle, pkt);
+            res = write_vtl_pkt(handle, pkt);
 
             prime_vtl_pkt_del(pkt);
         }

--- a/libhpcalcs/src/prime_cmd.h
+++ b/libhpcalcs/src/prime_cmd.h
@@ -48,6 +48,12 @@ HPEXPORT int HPCALL calc_prime_r_get_infos(calc_handle * handle, calc_infos * in
 HPEXPORT int HPCALL calc_prime_s_set_date_time(calc_handle * handle, time_t timestamp);
 HPEXPORT int HPCALL calc_prime_r_set_date_time(calc_handle * handle);
 
+HPEXPORT int HPCALL calc_prime_s_enable_new_protocol(calc_handle * handle);
+HPEXPORT int HPCALL calc_prime_r_enable_new_protocol(calc_handle * handle);
+
+HPEXPORT int HPCALL calc_prime_s_disable_new_protocol(calc_handle * handle);
+HPEXPORT int HPCALL calc_prime_r_disable_new_protocol(calc_handle * handle);
+
 HPEXPORT int HPCALL calc_prime_s_recv_screen(calc_handle * handle, calc_screenshot_format format);
 HPEXPORT int HPCALL calc_prime_r_recv_screen(calc_handle * handle, calc_screenshot_format format, uint8_t ** out_data, uint32_t * out_size);
 

--- a/libhpcalcs/src/prime_vpkt.c
+++ b/libhpcalcs/src/prime_vpkt.c
@@ -105,8 +105,6 @@ HPEXPORT int HPCALL prime_send_new_protocol_init(calc_handle * handle) {
         hpcalcs_info("%s: send init succeeded", __FUNCTION__);
     }
     
-    // Await response from Prime
-    
     return res;
 }
 


### PR DESCRIPTION
After upgrading my Prime to firmware version 2016 08 29 (10637), I noticed that sending large files from my PC onto the Prime did no longer work. The transfer always got stuck once the packet sequence number overflowed from 0xFE back to 0x00.

So I did some USB sniffing and reverse engineering on a Windows PC with the official connectivity kit. To my surprise, none of the packages, except for the very first roundtrip (where the connectivity kit retrieves version info from the Prime), looked like the packages we knew about. For starters, the package sequence numbers for commands all started with 0x01 rather than 0x00. But the packet header was also different, and significantly longer.
Finally I noticed that the connectivity kit compresses large files during the transfer. I haven't investigated which compression algorithm it's using. But basically it sets a different file type for the file transfer, and then transmits some kind of binary data that's smaller than the original file. Luckily this doesn't seem to be required for transmitting large files.

It took me quite a while to figure the new protocol out, but I finally got it working.

This patch implements the new protocol and uses it for file transfers from PC to the Prime. All other commands still use the old protocol. The new protocol must be enabled by sending a special packet to the prime. It must then be disabled again, or subsequent commands might not work. With this patch, this happens automatically within the send_file function.

I don't know if this was the precise version at which the old protocol broke, since I skipped a couple releases in the middle. I also don't know which version introduced the new protocol.

This patch *does not* implement backwards-compatibility for older Prime firmware versions. I think it's reasonable that users just check out an older revision if they don't want to upgrade?